### PR TITLE
Fixes - After review phase 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,9 @@ find_package(OpenMP REQUIRED)
 
 set(PROJECT_BINARY_DIR build)
 set (CMAKE_CXX_STANDARD 11)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -latomic -fopenmp")#${OpenMP_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")#${OpenMP_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -latomic -fopenmp")#${OpenMP_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 
 ###########################
 # adding sub directories 

--- a/src_erl/erlBridge/niftest.erl
+++ b/src_erl/erlBridge/niftest.erl
@@ -13,47 +13,27 @@
 -define(BUILD_TYPE,"release").
 -endif. 
 
--define(THIS_FILE_PATH_RELATIVE_TO_PROJECT_ROOT,"src_erl"). % if this file moves to inner place than update this define
+-define(NERLNET_DIR_STR,"NErlNet").
 -on_load(init/0).
 
+index_of(Item, List) -> index_of(Item, List, 1).
+index_of(_, [], _)  -> not_found;
+index_of(Item, [Item|_], Index) -> Index;
+index_of(Item, [_|Tl], Index) -> index_of(Item, Tl, Index+1).
+
 init() ->
-       %io:format("loading niff init()~n",[]),
-       {_,CWD} = file:get_cwd(), 
-       %io:format("CWD~p~n",[CWD]),
-       CWD_UPPER_DIR = re:replace(CWD,"/"++?THIS_FILE_PATH_RELATIVE_TO_PROJECT_ROOT,"",[{return,list}]),
-       %io:format("CWD_UPPER_DIR~p~n",[CWD_UPPER_DIR]),
-      
+       io:format("loading niff init()~n",[]),
+       {_,CWD} = file:get_cwd(),
+       SeparatedList = re:split(CWD,"/"),
+       SeparatedSubList = lists:sublist(SeparatedList,index_of(?NERLNET_DIR_STR,SeparatedList)),
+       NerlnetDir = lists:flatten(SeparatedSubList),
+       io:format("Nerlnet absolute Path~p~n",[NerlnetDir]),
    
-       %%FULL_PATH = CWD_UPPER_DIR++"/build/"++?BUILD_TYPE++"/libnerlnet",
+      FULL_PATH = NerlnetDir++"/build/"++?BUILD_TYPE++"/libnerlnet",
 
-   %  Full path
-      %  FULL_PATH = "/home/evgeny/work_test/NErlNet/build/release/libnerlnet",
-
-
-   % TODO TODO return to relative parh brfor commit to master. 
-      FULL_PATH = "../../../build/"++?BUILD_TYPE++"/libnerlnet",
-      % io:format("~p~n",[CWD_UPPER_DIR]),
       RES = erlang:load_nif(FULL_PATH, 0),
       io:format("load nif results: ~p",[RES]),
       ok.
-      % io:format("hello"),
-      %hello("hello").
-      %erlang:hello().
-      % erlang:nif_error("NIF library not loaded").
-
-%hello(Integer ) when is_integer(Integer) ->
-%      exit(nif_library_not_loaded).
-
-%
-%
-
-
-generateNormalDistributionList(Mean,Variance,SampleLength) ->
-      NewNormalDistributionList = [rand:normal(Mean,Variance) || _X <- lists:seq(1,round(SampleLength))], NewNormalDistributionList. 
-
-generateNormalDistributionSamples(0,_Mean,_Variance,_SampleLength,_ListOfSamples) -> _ListOfSamples;
-generateNormalDistributionSamples(N,Mean,Variance,SampleLength,ListOfSamples) -> generateNormalDistributionSamples(N-1,Mean,Variance,SampleLength,ListOfSamples ++ generateNormalDistributionList(Mean,Variance,SampleLength)).
-
 
 
 % ModelID - Unique ID of the neural network model 


### PR DESCRIPTION
- CMake list is changed
- niftest changed to find Nerlnet absolute path and concatenate build
dir

- Open a new issue about g++10 on raspbian - load nif results:
{error,{load_failed,"Failed to load NIF library:
'/home/pi/workspace/NErlNet/build/release/libnerlnet.so: undefined
symbol: __atomic_compare_exchange_8'