### PR TITLE
ci: run tests only if build pass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,8 +19,10 @@ jobs:
         run: |
           ./NerlnetInstall.sh
       - name: Build
+        id: build
         run: |
           ./NerlnetBuild.sh
-      - name: Run unitests
+      - name: Run unit tests
+        if: steps.build.outcome == 'success'
         run: |
           ./NerlnetTest.sh


### PR DESCRIPTION
Refactor GitHub Actions workflow to skip tests on build failure.
Previously, the GitHub Actions workflow would run the tests regardless of the build outcome.

Modified the 'build' job in the 'NerlnetInstall' workflow:
- Added 'id' to the 'Build' step to reference its outcome.
- Introduced an 'if' condition on the 'Run unit tests' step to check the outcome of the 'Build' step.
- The 'Run unit tests' step will only execute if the 'Build' step succeeds.